### PR TITLE
Modify list-style-type for example sentences and info glosses

### DIFF
--- a/jmdict.go
+++ b/jmdict.go
@@ -121,6 +121,7 @@ func jmdictSearchTerm(headword headword, entry jmdict.JmdictEntry, meta jmdictMe
 
 	term := dbTerm{
 		Expression: headword.Expression,
+		Reading:    headword.Reading,  // empty string
 		Sequence:   -entry.Sequence,
 	}
 

--- a/jmdict_constants.go
+++ b/jmdict_constants.go
@@ -23,7 +23,7 @@ const (
 
 	langMarker    = "'🌐 '"
 	noteMarker    = "'📝 '"
-	infoMarker    = "'ℹ️ '"
+	infoMarker    = "disc"
 	refMarker     = "'➡️ '"
 	antonymMarker = "'🔄 '"
 )

--- a/jmdict_glossary.go
+++ b/jmdict_glossary.go
@@ -154,7 +154,8 @@ func makeExampleListItem(sentence jmdict.JmdictExampleSentence) any {
 	} else {
 		attr := contentAttr{
 			lang:          ISOtoHTML[sentence.Lang],
-			listStyleType: ISOtoFlag[sentence.Lang],
+			listStyleType: "none",
+			fontSize:      "60%",
 		}
 		return contentListItem(attr, sentence.Text)
 	}
@@ -277,7 +278,7 @@ func createGlossaryContent(sense jmdict.JmdictSense, meta jmdictMetadata) any {
 		}
 	}
 	if len(exampleListItems) > 0 {
-		attr := listAttr(ISOtoHTML["jpn"], ISOtoFlag["jpn"], "examples")
+		attr := listAttr(ISOtoHTML["jpn"], "square", "examples")
 		list := contentUnorderedList(attr, exampleListItems...)
 		glossaryContents = append(glossaryContents, list)
 	}

--- a/jmdict_glossary.go
+++ b/jmdict_glossary.go
@@ -155,7 +155,7 @@ func makeExampleListItem(sentence jmdict.JmdictExampleSentence) any {
 		attr := contentAttr{
 			lang:          ISOtoHTML[sentence.Lang],
 			listStyleType: "none",
-			fontSize:      "60%",
+			fontSize:      "70%",
 		}
 		return contentListItem(attr, sentence.Text)
 	}


### PR DESCRIPTION
[I've received feedback](https://github.com/FooSoft/yomichan-import/pull/40#issuecomment-1426941717) from users of the new JMdict version for yomichan that the info emoji and the flag emojis do not display well in Chrome-based browsers.

I suggest changing these symbols to simple geometric shapes. These new symbols are more abstract, but it should be a better default for most users. Emojis can still be customized by [applying some custom CSS](https://github.com/FooSoft/yomichan-import/pull/40#issuecomment-1435359200).

I've changed the info emoji to a disc, the Japanese flag emoji to a square, and removed the UK flag emoji altogether. I also made the font size smaller for the English example sentences. I think these should still be legible at smaller sizes, and it will help save space.

<details>
  <summary>Example: 上方絵 and 上方 (before changes)</summary>

  ![ex4](https://user-images.githubusercontent.com/8003332/229924622-6d5b22de-ba93-478a-814c-0be7c22d9905.png)
</details>

<details>
  <summary>Example: 上方絵 and 上方 (after changes)</summary>

  ![ex1](https://user-images.githubusercontent.com/8003332/229918632-b2a1c538-daa5-4a07-b87d-05e399c47c2f.png)
</details>

<details>
  <summary>Example: 猫の手も借りたい (after changes)</summary>

![ex2](https://user-images.githubusercontent.com/8003332/229919589-d958b8af-f978-49a0-b601-06bceddea8ae.png)
</details>

<details>
  <summary>Example: 猫の手も借りたい (compact mode)</summary>
  
![ex3](https://user-images.githubusercontent.com/8003332/229919724-c33cbf62-dab3-426b-8da8-58219662a1f9.png)
</details>

Here's a copy of the dictionary with these proposed changes.
~~[jmdict_english_extra_with_examples.zip (04/04/2023)](https://github.com/themoeway/yomitan-import/files/11153219/jmdict_english_extra_with_examples.zip)~~
[jmdict_english_extra_with_examples.zip (04/09/2023)](https://github.com/themoeway/yomitan-import/files/11186067/jmdict_english_extra_with_examples.zip)