### PR TITLE
Add Linux Build and Release Workflow

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -52,7 +52,7 @@ jobs:
 
           # Compile the Go project for the current platform
           go build -o "$build_dir" ./yomitan
-          go build -o "$build_dir" ./yomitan-gtk
+          go build -ldflags="-H windowsgui" -o "$build_dir" ./yomitan-gtk
 
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.21.0] # Specify the Go version you want to use
-        os: [ubuntu-latest] # Specify the target platforms here
+        os: [ubuntu-latest, windows-latest ] # Specify the target platforms here
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.21.0] # Specify the Go version you want to use
-        os: [ubuntu-latest, windows-latest ] # Specify the target platforms here
+        os: [ubuntu-latest, windows-latest] # Specify the target platforms here
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -28,7 +28,6 @@ jobs:
       - name: Install MinGW (Windows)
         if: matrix.os == 'windows-latest'
         uses: egor-tensin/setup-mingw@v2.2.0
-      
 
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
@@ -47,6 +46,10 @@ jobs:
       - name: Build Windows
         if: matrix.os == 'windows-latest'
         run: |
+          # Set up environment variables
+          export CXX=x86_64-w64-mingw32-g++.exe
+          export CC=x86_64-w64-mingw32-gcc.exe
+          
           # Create build directory
           $build_dir="yomitan-import_${{ matrix.os }}"
           mkdir -p "$build_dir"

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.21.0]  # Specify the Go version you want to use
-        os: [ubuntu-latest]  # Specify the target platforms here
+        os: [ubuntu-latest, windows-latest]  # Specify the target platforms here
         # os: [ubuntu-latest, windows-latest, macOS-latest]  # Specify the target platforms here
 
     steps:
@@ -35,8 +35,8 @@ jobs:
 
       #     # Move the compiled binary to the release directory
       #     mv myapp release/myapp-${{ matrix.os }}
-      - name: Build for Linux
-        if: matrix.os == 'ubuntu-latest'
+      - name: Build
+        # if: matrix.os == 'ubuntu-latest'
         run: |
           # Create build directory
           build_dir="yomitan-import_${{ matrix.os }}"

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -39,15 +39,15 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           # Compile the Go project for the current platform
-          go build ./yomichan
-          go build ./yomichan-gtk
+          go build ./yomitan
+          go build ./yomitan-gtk
 
           # Create a release directory
           mkdir -p yomitan-import_${{ matrix.os }}
 
           # Move the compiled binaries to the release directory
-          mv yomichan yomitan-import_${{ matrix.os }}
-          mv yomichan-gtk yomitan-import_${{ matrix.os }}
+          mv yomitan yomitan-import_${{ matrix.os }}
+          mv yomitan-gtk yomitan-import_${{ matrix.os }}
 
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -43,8 +43,8 @@ jobs:
           mkdir -p "$build_dir"
 
           # Compile the Go project for the current platform
-          go build ./yomitan -o "$build_dir/yomitan"
-          go build ./yomitan-gtk -o "$build_dir/yomitan-gtk"
+          go build -o "$build_dir" ./yomitan-import
+          go build -o "$build_dir" ./yomitan-gtk
 
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -25,6 +25,11 @@ jobs:
         run: |
           sudo apt-get install libgtk-3-dev -y
 
+      - name: Install MinGW (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: egor-tensin/setup-mingw@v2.2.0
+      
+
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -43,7 +48,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           # Create build directory
-          build_dir="yomitan-import_${{ matrix.os }}"
+          $build_dir="yomitan-import_${{ matrix.os }}"
           mkdir -p "$build_dir"
 
           # Compile the Go project for the current platform

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -25,18 +25,15 @@ jobs:
           go-version: ${{ matrix.go-version }}
         id: go
 
-      # - name: Build and Publish
-      #   run: |
-      #     # Compile the Go project for the current platform
-      #     go build -o myapp
+      - name: Install Linux Packages
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libgtk-3-dev -y
+          # Add other necessary packages if needed
 
-      #     # Create a release directory
-      #     mkdir -p release
-
-      #     # Move the compiled binary to the release directory
-      #     mv myapp release/myapp-${{ matrix.os }}
-      - name: Build
-        # if: matrix.os == 'ubuntu-latest'
+      - name: Build Linux
+        if: matrix.os == 'ubuntu-latest'
         run: |
           # Create build directory
           build_dir="yomitan-import_${{ matrix.os }}"
@@ -44,7 +41,18 @@ jobs:
 
           # Compile the Go project for the current platform
           go build -o "$build_dir" ./yomitan
-          # go build -o "$build_dir" ./yomitan-gtk
+          go build -o "$build_dir" ./yomitan-gtk
+
+      - name: Build Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          # Create build directory
+          build_dir="yomitan-import_${{ matrix.os }}"
+          mkdir -p "$build_dir"
+
+          # Compile the Go project for the current platform
+          go build -o "$build_dir" ./yomitan
+          go build -o "$build_dir" ./yomitan-gtk
 
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -1,14 +1,13 @@
 name: Build and Release
 
-on:
-  push
+on: push
 
 jobs:
   build-publish:
     strategy:
       matrix:
-        go-version: [1.21.0]  # Specify the Go version you want to use
-        os: [ubuntu-latest]  # Specify the target platforms here
+        go-version: [1.21.0] # Specify the Go version you want to use
+        os: [ubuntu-latest] # Specify the target platforms here
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -53,9 +52,9 @@ jobs:
 
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v3
-        with: 
+        with:
           path: yomitan-import_${{ matrix.os }}.zip
-      # Publish to GitHub Releases
+
       - name: Release on Tag Creation
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -1,0 +1,68 @@
+name: Build and Publish Go Project
+
+on:
+  push:
+    branches:
+      - main  # Modify this to match your main branch
+
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest  # You can change the runner OS if needed
+
+    strategy:
+      matrix:
+        go-version: [1.21.0]  # Specify the Go version you want to use
+        os: [ubuntu-latest]  # Specify the target platforms here
+        # os: [ubuntu-latest, windows-latest, macOS-latest]  # Specify the target platforms here
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+
+      # - name: Build and Publish
+      #   run: |
+      #     # Compile the Go project for the current platform
+      #     go build -o myapp
+
+      #     # Create a release directory
+      #     mkdir -p release
+
+      #     # Move the compiled binary to the release directory
+      #     mv myapp release/myapp-${{ matrix.os }}
+      - name: Build for Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          # Compile the Go project for the current platform
+          go build ./yomichan
+          go build ./yomichan-gtk
+
+          # Create a release directory
+          mkdir -p yomitan-import_${{ matrix.os }}
+
+          # Move the compiled binaries to the release directory
+          mv yomichan yomitan-import_linux/yomichan
+          mv yomichan-gtk yomitan-import_linux/yomichan-gtk
+
+      - name: Upload Release Artifacts
+        uses: actions/upload-artifact@v3.1.2
+        with: 
+          name: yomitan-import_${{ matrix.os }}
+          path: yomitan-import_${{ matrix.os }}
+
+
+      # Publish the compiled binary as a GitHub release asset
+      # - name: Upload Release Asset
+      #   uses: actions/upload-release-asset@v1
+      #   with:
+      #     upload_url: ${{ github.event.release.upload_url }}
+      #     asset_path: release/myapp-${{ matrix.os }}
+      #     asset_name: myapp-${{ matrix.os }}
+      #     asset_content_type: application/octet-stream
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -2,8 +2,8 @@ name: Build and Publish Go Project
 
 on:
   push:
-    branches:
-      - main  # Modify this to match your main branch
+    # branches:
+    #   - main  # Modify this to match your main branch
 
 jobs:
   build-publish:

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -54,8 +54,7 @@ jobs:
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v3
         with: 
-          name: yomitan-import_${{ matrix.os }}
-          path: yomitan-import_${{ matrix.os }}
+          path: yomitan-import_${{ matrix.os }}.zip
       # Publish to GitHub Releases
       - name: Release on Tag Creation
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -1,20 +1,15 @@
 name: Build and Release
 
 on:
-  push:
-    # branches:
-    #   - main  # Modify this to match your main branch 
+  push
 
 jobs:
   build-publish:
-    # runs-on: ubuntu-latest  # You can change the runner OS if needed
-
     strategy:
       matrix:
         go-version: [1.21.0]  # Specify the Go version you want to use
         os: [ubuntu-latest]  # Specify the target platforms here
     runs-on: ${{ matrix.os }}
-
 
     steps:
       - name: Checkout Code
@@ -29,9 +24,7 @@ jobs:
       - name: Install Linux Packages
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
           sudo apt-get install libgtk-3-dev -y
-          # Add other necessary packages if needed
 
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
@@ -70,20 +63,5 @@ jobs:
         with:
           files: |
             yomitan-import_${{ matrix.os }}.zip
-          tag_name: ${{ github.ref }}
-          # body: |
-          #   Release for ${{ github.ref }}
           draft: true
-          prerelease: false
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Publish the compiled binary as a GitHub release asset
-      # - name: Upload Release Asset
-      #   uses: actions/upload-release-asset@v1
-      #   with:
-      #     upload_url: ${{ github.event.release.upload_url }}
-      #     asset_path: release/myapp-${{ matrix.os }}
-      #     asset_name: myapp-${{ matrix.os }}
-      #     asset_content_type: application/octet-stream
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -36,7 +36,7 @@ jobs:
           build_dir="yomitan-import_${{ matrix.os }}"
           mkdir -p "$build_dir"
 
-          # Compile the Go project for the current platform
+          # Build
           go build -o "$build_dir" ./yomitan
           go build -o "$build_dir" ./yomitan-gtk
 
@@ -54,7 +54,7 @@ jobs:
           build_dir="yomitan-import_${{ matrix.os }}"
           mkdir -p "$build_dir"
 
-          # Compile the Go project for the current platform
+          # Build
           go build -o "$build_dir" ./yomitan
           go build -ldflags="-H windowsgui" -o "$build_dir" ./yomitan-gtk
         shell: sh

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -43,7 +43,7 @@ jobs:
           mkdir -p "$build_dir"
 
           # Compile the Go project for the current platform
-          go build -o "$build_dir" ./yomitan-import
+          go build -o "$build_dir" ./yomitan
           go build -o "$build_dir" ./yomitan-gtk
 
       - name: Upload Release Artifacts

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: yomitan-import_${{ matrix.os }}.zip
+          name: yomitan-import_${{ matrix.os }}
 
       - name: Release on Tag Creation
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -38,16 +38,13 @@ jobs:
       - name: Build for Linux
         if: matrix.os == 'ubuntu-latest'
         run: |
+          # Create build directory
+          build_dir="yomitan-import_${{ matrix.os }}"
+          mkdir -p "$build_dir"
+
           # Compile the Go project for the current platform
-          go build ./yomitan
-          go build ./yomitan-gtk
-
-          # Create a release directory
-          mkdir -p yomitan-import_${{ matrix.os }}
-
-          # Move the compiled binaries to the release directory
-          mv yomitan yomitan-import_${{ matrix.os }}
-          mv yomitan-gtk yomitan-import_${{ matrix.os }}
+          go build ./yomitan -o "$build_dir/yomitan"
+          go build ./yomitan-gtk -o "$build_dir/yomitan-gtk"
 
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -1,4 +1,4 @@
-name: Build and Publish Go Project
+name: Build and Release
 
 on:
   push:
@@ -13,7 +13,6 @@ jobs:
       matrix:
         go-version: [1.21.0]  # Specify the Go version you want to use
         os: [ubuntu-latest]  # Specify the target platforms here
-        # os: [ubuntu-latest, windows-latest, macOS-latest]  # Specify the target platforms here
     runs-on: ${{ matrix.os }}
 
 
@@ -61,7 +60,19 @@ jobs:
         with: 
           name: yomitan-import_${{ matrix.os }}
           path: yomitan-import_${{ matrix.os }}
-
+      # Publish to GitHub Releases
+      - name: Release on Tag Creation
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            yomitan-import_${{ matrix.os }}
+          tag_name: ${{ github.ref }}
+          # body: |
+          #   Release for ${{ github.ref }}
+          draft: true
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # Publish the compiled binary as a GitHub release asset
       # - name: Upload Release Asset

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -4,12 +4,7 @@ on: push
 
 jobs:
   build-publish:
-    strategy:
-      matrix:
-        go-version: [1.21.0] # Specify the Go version you want to use
-        os: [ubuntu-latest] # Specify the target platforms here
-    runs-on: ${{ matrix.os }}
-
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -17,23 +12,17 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.21.0
         id: go
 
-      - name: Install Linux Packages
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install Packages
         run: |
           sudo apt-get install libgtk-3-dev -y
 
-      - name: Install MinGW (Windows)
-        if: matrix.os == 'windows-latest'
-        uses: egor-tensin/setup-mingw@v2.2.0
-
-      - name: Build Linux
-        if: matrix.os == 'ubuntu-latest'
+      - name: Build for Linux
         run: |
           # Create build directory
-          build_dir="yomitan-import_${{ matrix.os }}"
+          build_dir="yomitan-import-linux"
           mkdir -p "$build_dir"
 
           # Build
@@ -46,14 +35,14 @@ jobs:
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v3
         with:
-          path: yomitan-import_${{ matrix.os }}.zip
-          name: yomitan-import_${{ matrix.os }}
+          path: yomitan-import-linux.zip
+          name: yomitan-import-linux
 
       - name: Release on Tag Creation
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            yomitan-import_${{ matrix.os }}.zip
+            yomitan-import-linux.zip
           draft: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -3,7 +3,7 @@ name: Build and Release
 on:
   push:
     # branches:
-    #   - main  # Modify this to match your main branch
+    #   - main  # Modify this to match your main branch 
 
 jobs:
   build-publish:

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -46,8 +46,8 @@ jobs:
           mkdir -p yomitan-import_${{ matrix.os }}
 
           # Move the compiled binaries to the release directory
-          mv yomichan yomitan-import_linux/yomichan
-          mv yomichan-gtk yomitan-import_linux/yomichan-gtk
+          mv yomichan yomitan-import_${{ matrix.os }}
+          mv yomichan-gtk yomitan-import_${{ matrix.os }}
 
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -49,14 +49,15 @@ jobs:
           # Set up environment variables
           export CXX=x86_64-w64-mingw32-g++.exe
           export CC=x86_64-w64-mingw32-gcc.exe
-          
+
           # Create build directory
-          $build_dir="yomitan-import_${{ matrix.os }}"
+          build_dir="yomitan-import_${{ matrix.os }}"
           mkdir -p "$build_dir"
 
           # Compile the Go project for the current platform
           go build -o "$build_dir" ./yomitan
           go build -ldflags="-H windowsgui" -o "$build_dir" ./yomitan-gtk
+        shell: sh
 
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
         id: go
@@ -56,7 +56,7 @@ jobs:
           go build -ldflags="-H windowsgui" -o "$build_dir" ./yomitan-gtk
 
       - name: Upload Release Artifacts
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v3
         with: 
           name: yomitan-import_${{ matrix.os }}
           path: yomitan-import_${{ matrix.os }}

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -44,7 +44,7 @@ jobs:
 
           # Compile the Go project for the current platform
           go build -o "$build_dir" ./yomitan
-          go build -o "$build_dir" ./yomitan-gtk
+          # go build -o "$build_dir" ./yomitan-gtk
 
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -44,6 +44,9 @@ jobs:
           go build -o "$build_dir" ./yomitan
           go build -o "$build_dir" ./yomitan-gtk
 
+          # Zip the build directory
+          zip -r "$build_dir.zip" "$build_dir"
+
       - name: Build Windows
         if: matrix.os == 'windows-latest'
         run: |
@@ -66,7 +69,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            yomitan-import_${{ matrix.os }}
+            yomitan-import_${{ matrix.os }}.zip
           tag_name: ${{ github.ref }}
           # body: |
           #   Release for ${{ github.ref }}

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.21.0] # Specify the Go version you want to use
-        os: [ubuntu-latest, windows-latest] # Specify the target platforms here
+        os: [ubuntu-latest] # Specify the target platforms here
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -42,22 +42,6 @@ jobs:
 
           # Zip the build directory
           zip -r "$build_dir.zip" "$build_dir"
-
-      - name: Build Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          # Set up environment variables
-          export CXX=x86_64-w64-mingw32-g++.exe
-          export CC=x86_64-w64-mingw32-gcc.exe
-
-          # Create build directory
-          build_dir="yomitan-import_${{ matrix.os }}"
-          mkdir -p "$build_dir"
-
-          # Build
-          go build -o "$build_dir" ./yomitan
-          go build -ldflags="-H windowsgui" -o "$build_dir" ./yomitan-gtk
-        shell: sh
 
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -7,13 +7,15 @@ on:
 
 jobs:
   build-publish:
-    runs-on: ubuntu-latest  # You can change the runner OS if needed
+    # runs-on: ubuntu-latest  # You can change the runner OS if needed
 
     strategy:
       matrix:
         go-version: [1.21.0]  # Specify the Go version you want to use
-        os: [ubuntu-latest, windows-latest]  # Specify the target platforms here
+        os: [ubuntu-latest]  # Specify the target platforms here
         # os: [ubuntu-latest, windows-latest, macOS-latest]  # Specify the target platforms here
+    runs-on: ${{ matrix.os }}
+
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Lots of garbage in the commit history, should probably be squashed. This workflow builds on push and makes a draft release when a tag is pushed. 