### PR TITLE
Remove needsStructuredContent requirement for extraMode dictionaries

### DIFF
--- a/jmdict_glossary.go
+++ b/jmdict_glossary.go
@@ -287,7 +287,7 @@ func createGlossaryContent(sense jmdict.JmdictSense, meta jmdictMetadata) any {
 
 func createGlossary(sense jmdict.JmdictSense, meta jmdictMetadata) []any {
 	glossary := []any{}
-	if meta.extraMode && needsStructuredContent(sense, meta.language) {
+	if meta.extraMode {
 		glossary = append(glossary, createGlossaryContent(sense, meta))
 	} else {
 		for _, gloss := range sense.Glossary {


### PR DESCRIPTION
Turning on and off structured content makes dictionary formatting inconsistent. This makes it so structured content is always used for extraMode dictionary glosses.

The only dictionaries using this in [jmdict-yomitan](https://github.com/themoeway/jmdict-yomitan) are `JMdict_english_with_examples.zip` and `JMdict_english.zip`. This does not touch any other dicts and only changes the output of dicts with the language set to `"english_extra"`.

https://github.com/themoeway/yomitan-import/blob/6c071bca823a2f0737e2f46562717c8433ebde73/jmdict_metadata.go#L151
